### PR TITLE
fixing RBAC permissions for approving CSRs

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -51,6 +51,7 @@ rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["signers"]
     verbs: ["approve"]
+    resourceNames: ["kubernetes.io/kubelet-serving"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -48,6 +48,9 @@ rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests/approval"]
     verbs: ["update"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["signers"]
+    verbs: ["approve"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
as described [here](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#authorization) the SA also needs permissions to approve a specific signer. This failed on an OCP4 cluster (user not permitted to approve requests with signerName "kubernetes.io/kubelet-serving") and was fixed with this additional permission